### PR TITLE
Initial Python 3 support

### DIFF
--- a/lib/dvr.py
+++ b/lib/dvr.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 import time, threading
 import xbmc, xbmcgui
-import kodigui
-import hdhr
-import skin
-import record
+from . import kodigui
+from . import hdhr
+from . import skin
+from . import record
 
-import util
-from util import T
+from . import util
+from .util import T
 
 
 class EpisodesDialog(kodigui.BaseDialog):

--- a/lib/hdhr/__init__.py
+++ b/lib/hdhr/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-import errors #analysis:ignore
-import tuners #analysis:ignore
-import storageservers #analysis:ignore
-import guide #analysis:ignore
-import discovery #analysis:ignore
+from . import errors #analysis:ignore
+from . import tuners #analysis:ignore
+from . import storageservers #analysis:ignore
+from . import guide #analysis:ignore
+from . import discovery #analysis:ignore

--- a/lib/hdhr/crc32c.py
+++ b/lib/hdhr/crc32c.py
@@ -78,7 +78,7 @@ def add(crc, buf):
     return crc
 
 def done(crc):
-    tmp = ~crc & 0xffffffffL
+    tmp = ~crc & 0xffffffff
     b0 = tmp & 0xff
     b1 = (tmp >> 8) & 0xff
     b2 = (tmp >> 16) & 0xff
@@ -88,4 +88,4 @@ def done(crc):
 
 def cksum(buf):
     """Return computed CRC-32c checksum."""
-    return done(add(0xffffffffL, buf))
+    return done(add(0xffffffff, buf))

--- a/lib/hdhr/discovery.py
+++ b/lib/hdhr/discovery.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
-import crc32c
+from . import crc32c
 import binascii
 import socket
 import traceback
 import struct
-import StringIO
+from io import BytesIO
 import time
 import base64
 import requests
-import errors
+from . import errors
 from lib import util
 
 DEVICE_DISCOVERY_PORT = 65001
@@ -52,7 +52,7 @@ class Devices(object):
         self.discover()
 
     def discover(self, device=None):
-        import netif
+        from . import netif
         ifaces = netif.getInterfaces()
         sockets = []
         for i in ifaces:
@@ -114,7 +114,7 @@ class Devices(object):
 
     @property
     def allDevices(self):
-        return self.tunerDevices + self.storageServers + self._other
+        return list(self.tunerDevices) + self.storageServers + self._other
 
     def isOld(self):
         return (time.time() - self._discoveryTimestamp) > self.MAX_AGE
@@ -159,7 +159,7 @@ class Devices(object):
             traceback.print_exc()
             return None
 
-        dataIO = StringIO.StringIO(data)
+        dataIO = BytesIO(data)
 
         tag, length = struct.unpack('>BB',dataIO.read(2))
         deviceType = struct.unpack('>I',dataIO.read(length))[0]
@@ -211,7 +211,7 @@ class Devices(object):
         return True
 
     def getDeviceByIP(self,ip):
-        for d in self.tunerDevices + self.storageServers:
+        for d in list(self.tunerDevices) + self.storageServers:
             if d.ip == ip:
                 return d
         return None
@@ -223,7 +223,7 @@ class Devices(object):
             ids.append(d.ID)
             authID = d.deviceAuth
             if not authID: continue
-            combined += authID
+            combined += authID.decode('utf-8')
 
         if not combined:
             util.LOG('WARNING: No device auth for any devices!')
@@ -275,6 +275,7 @@ class TunerDevice(Device):
         if not url:
             url = LINEUP_URL_BASE.format(ip=self.ip)
 
+        if isinstance(url, (bytes,bytearray)): url = url.decode('utf-8')
         if '?' in url:
             url += '&show=demo'
         else:

--- a/lib/hdhr/guide.py
+++ b/lib/hdhr/guide.py
@@ -12,7 +12,7 @@ except:
     from ordereddict_compat import OrderedDict
 
 from lib import util
-import errors
+from . import errors
 
 GUIDE_URL = 'http://api.hdhomerun.com/api/guide.php?DeviceAuth={0}'
 SLICE_URL = 'http://api.hdhomerun.com/api/guide.php?DeviceAuth={deviceAuth}&Channel={channel}{start}'
@@ -602,7 +602,7 @@ class Guide(object):
         self.guide = OrderedDict()
         if not lineup:
             return
-        url = GUIDE_URL.format(urllib.quote(lineup.apiAuthID(),''))
+        url = GUIDE_URL.format(urllib.parse.quote(lineup.apiAuthID(),''))
 
         data = self.getData(url)
 

--- a/lib/hdhr/storageservers.py
+++ b/lib/hdhr/storageservers.py
@@ -2,8 +2,8 @@
 import requests
 import urllib
 import time
-import guide
-import errors
+from . import guide
+from . import errors
 from lib import util
 
 MY = 'api'

--- a/lib/hdhr/tuners.py
+++ b/lib/hdhr/tuners.py
@@ -7,7 +7,7 @@ except:
     from ordereddict_compat import OrderedDict
 
 from lib import util
-import errors
+from . import errors
 
 
 def chanTuple(guide_number,chanCount):
@@ -69,7 +69,7 @@ class LineUp(object):
 
     def index(self,key):
         if not key in self.channels: return -1
-        return self.channels.keys().index(key)
+        return list(self.channels.keys()).index(key)
 
     def indexed(self,index):
         if index < 0 or index >= len(self):

--- a/lib/main.py
+++ b/lib/main.py
@@ -2,14 +2,14 @@
 import time, random, threading
 import xbmc, xbmcgui
 
-import actionconstants
-import hdhr
-import kodigui
-import util
-import player
-import skin
-import dvr
-import record
+from . import actionconstants
+from . import hdhr
+from . import kodigui
+from . import util
+from . import player
+from . import skin
+from . import dvr
+from . import record
 
 API_LEVEL = 2
 

--- a/lib/player.py
+++ b/lib/player.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import xbmc, xbmcgui
-import util
+from . import util
 
 TRANSCODE_PROFILES = (None,'none','heavy','mobile','internet540','internet480','internet360','internet240')
 
@@ -147,7 +147,7 @@ class FullsceenVideoInitializer(xbmc.Player):
         self._finished = False
         if self.isPlaying():
             return self.finish()
-        dummy = os.path.join(xbmc.translatePath(util.ADDON.getAddonInfo('path')).decode('utf-8'),'resources','dummy.mp4')
+        dummy = os.path.join(xbmc.translatePath(util.ADDON.getAddonInfo('path')),'resources','dummy.mp4')
         self.play(dummy)
         while not self._finished:
             xbmc.sleep(100)

--- a/lib/record.py
+++ b/lib/record.py
@@ -2,11 +2,11 @@ import re
 
 import xbmc
 import xbmcgui
-import kodigui
-import hdhr
+from . import kodigui
+from . import hdhr
 
-import util
-from util import T
+from . import util
+from .util import T
 
 class RecordDialog(kodigui.BaseDialog):
     EPISODE_LIST = 201

--- a/lib/skin.py
+++ b/lib/skin.py
@@ -2,7 +2,7 @@
 import os
 import json
 import xbmc, xbmcvfs
-import util
+from . import util
 
 #Skins that work without font modification:
 #
@@ -36,8 +36,8 @@ FONT_TRANSLATIONS = {
 FONTS = ('font10','font13','font30')
 
 VERSION = util.ADDON.getAddonInfo('version')
-VERSION_FILE = os.path.join(xbmc.translatePath(util.ADDON.getAddonInfo('profile')).decode('utf-8'),'skin','version')
-KODI_VERSION_FILE = os.path.join(xbmc.translatePath(util.ADDON.getAddonInfo('profile')).decode('utf-8'),'skin','kodi_version')
+VERSION_FILE = os.path.join(xbmc.translatePath(util.ADDON.getAddonInfo('profile')),'skin','version')
+KODI_VERSION_FILE = os.path.join(xbmc.translatePath(util.ADDON.getAddonInfo('profile')),'skin','kodi_version')
 
 def skinningAPIisOld():
     try:
@@ -86,19 +86,19 @@ def currentKodiSkin():
 
 def setupDynamicSkin():
     import shutil
-    targetDir = os.path.join(xbmc.translatePath(util.ADDON.getAddonInfo('profile')).decode('utf-8'),'skin','resources')
+    targetDir = os.path.join(xbmc.translatePath(util.ADDON.getAddonInfo('profile')),'skin','resources')
     target = os.path.join(targetDir,'skins')
 
     if os.path.exists(target):
         shutil.rmtree(target,True)
     if not os.path.exists(targetDir): os.makedirs(targetDir)
 
-    source = os.path.join(xbmc.translatePath(util.ADDON.getAddonInfo('path')).decode('utf-8'),'resources','skins')
+    source = os.path.join(xbmc.translatePath(util.ADDON.getAddonInfo('path')),'resources','skins')
     copyTree(source,target)
 
 def customizeSkinXML(skin,xml):
-    source = os.path.join(xbmc.translatePath(util.ADDON.getAddonInfo('path')).decode('utf-8'),'resources','skins','Main','1080i',xml)
-    target = os.path.join(xbmc.translatePath(util.ADDON.getAddonInfo('profile')).decode('utf-8'),'skin','resources','skins','Main','1080i',xml)
+    source = os.path.join(xbmc.translatePath(util.ADDON.getAddonInfo('path')),'resources','skins','Main','1080i',xml)
+    target = os.path.join(xbmc.translatePath(util.ADDON.getAddonInfo('profile')),'skin','resources','skins','Main','1080i',xml)
     with open(source,'r') as s:
         data = s.read()
 
@@ -129,7 +129,6 @@ def kodiHasOldStringInfoLabels():
 
 def getKodiVersion():
     json_query = xbmc.executeJSONRPC('{ "jsonrpc": "2.0", "method": "Application.GetProperties", "params": {"properties": ["version", "name"]}, "id": 1 }')
-    json_query = unicode(json_query, 'utf-8', errors='ignore')
     json_query = json.loads(json_query)
     return json_query['result']['version']
 
@@ -157,4 +156,4 @@ def getSkinPath():
             util.ERROR()
             return default
 
-    return os.path.join(xbmc.translatePath(util.ADDON.getAddonInfo('profile')).decode('utf-8'),'skin')
+    return os.path.join(xbmc.translatePath(util.ADDON.getAddonInfo('profile')),'skin')

--- a/lib/util.py
+++ b/lib/util.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import sys, binascii, json, threading, time, datetime
 import xbmc, xbmcgui, xbmcaddon, xbmcvfs
-import verlib
+from . import verlib
 
 DEBUG = True
 
@@ -17,8 +17,7 @@ def DEBUG_LOG(msg):
     LOG(msg)
 
 def ERROR(txt='',hide_tb=False,notify=False):
-    if isinstance (txt,str): txt = txt.decode("utf-8")
-    short = str(sys.exc_info()[1])
+    short = sys.exc_info()[1]
     if hide_tb:
         xbmc.log('script.hdhomerun.view: ERROR: {0} - {1}'.format(txt,short),xbmc.LOGERROR)
         return short
@@ -74,7 +73,7 @@ def getGlobalProperty(key):
 
 def showNotification(message,time_ms=3000,icon_path=None,header=ADDON.getAddonInfo('name')):
     try:
-        icon_path = icon_path or xbmc.translatePath(ADDON.getAddonInfo('icon')).decode('utf-8')
+        icon_path = icon_path or xbmc.translatePath(ADDON.getAddonInfo('icon'))
         xbmc.executebuiltin('Notification({0},{1},{2},{3})'.format(header,message,time_ms,icon_path))
     except RuntimeError: #Happens when disabling the addon
         LOG(message)


### PR DESCRIPTION
I have tested this with Kodi 18 on Fedora 32, which is compiled to use Python 3 instead of Python 2. Without these changes the add-on will not work with Python 3 or Kodi 19, etc.