### PR TITLE
Fix for buffering of live channels a few seconds after playback starts

### DIFF
--- a/lib/player.py
+++ b/lib/player.py
@@ -107,6 +107,7 @@ class HDHRPlayer(xbmc.Player):
                 'Studio': channel.guide.affiliate
         }
         item.setInfo('video', info)
+        item.setProperty('isrealtimestream', 'true')
         util.setSetting('last.channel', channel.number)
         self.status('NOT_STARTED',channel,item)
         args = self.getArgs()


### PR DESCRIPTION
PR issues a fix to the buffering that will occur after playback starts on a live channel.  Flagging the stream as realtime changes the playback and buffering semantics.

The same problem occurs with binary PVR addons if live TV HDHomeRun streams aren't flagged as realtime.