### PR TITLE
Fix recordings when used with updated RECORD engine(s)

### DIFF
--- a/lib/hdhr/discovery.py
+++ b/lib/hdhr/discovery.py
@@ -346,15 +346,22 @@ class StorageServer(Device):
         except:
             util.ERROR('Failed to format {0} info'.format(self.typeName),hide_tb=True)
 
-    def recordings(self):
-        util.DEBUG_LOG('Getting recordings from: {0}'.format(self.storageURL))
-        req = requests.get(self.storageURL)
+    def recordedSeries(self):
+        storageUrl = self.storageURL
+
+        if '?' in storageUrl:
+            storageUrl += '&DisplayGroupID=root'
+        else:
+            storageUrl += '?DisplayGroupID=root'
+
+        util.DEBUG_LOG('Getting recorded series from: {0}'.format(storageUrl))
+        req = requests.get(storageUrl)
 
         try:
-            recordings = req.json()
-            return recordings
+            recordedSeries = req.json()
+            return recordedSeries
         except:
-            util.ERROR('Failed to parse recordings JSON data.',hide_tb=True)
+            util.ERROR('Failed to parse recorded series JSON data.',hide_tb=True)
             return None
 
     def syncRules(self):

--- a/lib/hdhr/storageservers.py
+++ b/lib/hdhr/storageservers.py
@@ -200,6 +200,48 @@ class RecordingRule(dict):
 
         return self
 
+#"SeriesID":"MV008857200000",
+#"Title":"Adventures in Babysitting"
+#"Category":"movie",
+#"ImageURL":"http://img.hdhomerun.com/titles/MV008857200000.jpg",
+#"PosterURL":"http://img.hdhomerun.com/posters/MV008857200000.jpg",
+#"StartTime":1589760000,
+#"EpisodesURL":"http://192.168.0.220:50000/recorded_files.json?SeriesID=MV008857200000",
+#"UpdateID":911500988
+
+class RecordedSeries(dict):
+    @property
+    def ID(self):
+        return self.get('SeriesID')
+
+    @property
+    def title(self):
+        return self.get('Title', '')
+
+    @property
+    def category(self):
+        return self.get('Category', 'series')
+
+    @property
+    def icon(self):
+        return self.get('ImageURL', '')
+
+    @property
+    def poster(self):
+        return self.get('PosterURL', '')
+
+    @property
+    def startTimestamp(self):
+        return int(self.get('StartTime', 0))
+
+    @property
+    def episodesURL(self):
+        return self.get('EpisodesURL', '')
+
+    @property
+    def updateID(self):
+        return int(self.get('UpdateID', 0))
+
 #"ChannelAffiliate":"CBS",
 #"ChannelImageURL":"http://my.hdhomerun.com/fyimediaservices/v_3_3_6_1/Station.svc/2/765/Logo/120x120",
 #"ChannelName":"KIRO-DT",
@@ -305,8 +347,13 @@ class StorageServers(object):
         err = None
         for d in self._devices.storageServers:
             try:
-                recs = d.recordings()
-                if recs: self._recordings += [Recording(r) for r in recs]
+                recseries = [RecordedSeries(s) for s in d.recordedSeries()]
+                if recseries:
+                    for rs in recseries:
+                        req = requests.get(rs.episodesURL)
+                        recs = req.json()
+                        if recs: 
+                            self._recordings += [Recording(r) for r in recs]
             except:
                 err = util.ERROR()
 


### PR DESCRIPTION
PR is a fairly quick and dirty fix to allow recordings to work again with the updated RECORD engine schema.

Change adapts to the need to first iterate the recorded series via recorded_files.json?DisplayGroupID=root.  DisplayGroupID=root is done as per SD's suggestion to maintain compatibility with older RECORD engines.  The list of series is then iterated to expose the individual recordings.

The implementation could be improved on, for example the UpdateID can now be used to determine if recordings should be refreshed or not, my goal was to just make it work with as little damage path as possible since this is quite literally the first time I've ever used Python :)