### PR TITLE
Fix tuner fallback mechanism based on player status

### DIFF
--- a/lib/player.py
+++ b/lib/player.py
@@ -57,7 +57,7 @@ class HDHRPlayer(xbmc.Player):
 
         return self
 
-    def onPlayBackStarted(self):
+    def onAVStarted(self):
         self.status('STARTED')
         if False and self.status.channel:
             util.DEBUG_LOG('Saving successful channel number as last: {0}'.format(self.status.channel.number))


### PR DESCRIPTION
PR fixes the inbuilt channel source fallback mechanism, which will be required for an expected follow-on PR to support streaming from the HDHomeRun RECORD engine when available.  HDHomeRun RECORD channel requests may fail due to user configuration (maxstreams), which will necessitate that the fallback mechanism to other available RECORD engines or the tuners be functional.

Kodi was calling onPlayBackStarted() regardless of being able to actually open the stream, falsely flagging the status as 'STARTED', and disabling the fallback mechanism supplied by onPlayBackFailed().

This fix in and of itself is standalone and corrects existing ill behavior.  Tested by forcing the first URL sent to the player to be bad, causing onAVStarted() to never be called, and fallback to the second tuner (with accurate URL) worked seamlessly.