### PR TITLE
Set MIME type to (marginally) increase tuning performance

### DIFF
--- a/lib/player.py
+++ b/lib/player.py
@@ -107,6 +107,7 @@ class HDHRPlayer(xbmc.Player):
                 'Studio': channel.guide.affiliate
         }
         item.setInfo('video', info)
+        item.setMimeType('video/mp2t')
         util.setSetting('last.channel', channel.number)
         self.status('NOT_STARTED',channel,item)
         args = self.getArgs()
@@ -117,6 +118,7 @@ class HDHRPlayer(xbmc.Player):
         li.setInfo('video',{'duration':str(rec.duration/60),'title':rec.episodeTitle,'tvshowtitle':rec.seriesTitle})
         li.addStreamInfo('video',{'duration':rec.duration})
         li.setIconImage(rec.icon)
+        li.setMimeType('video/mp2t')
         self.play(rec.playURL,li,self.touchMode,0)
 
     def isPlayingHDHR(self):


### PR DESCRIPTION
While this does not appreciably improve anything at all, setting a MIME type hint for the stream prior to opening it via the Kodi player object does improve performance, if just slightly. 

All HDHomeRun streams are MPEG-TS, and the proper MIME type hint to supply to Kodi in this case is "video/mp2t".  Again, any improvement is difficult to measure, but "feels" a tad faster.

This change may help some, but should not hurt any.